### PR TITLE
Specify-locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ textra [options] FILE1 [FILE2...] [outputOptions]
 
 **`-s`, `--silent`**: Suppress non-essential output
 
+**`-l`, `--locale`**: Specify a [locale](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html) (e.g. en-US) for text recognition
+
 **`-v`, `--version`**: Show version number
 
 ### Output options

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ if [[ $(sw_vers -productVersion | cut -d . -f 1) -lt 13 ]]; then
     error 'Mac OS 13 or greater is required to run textra since it depends on Apple''s updated Vision APIs. Please upgrade your Mac and try again.'
 fi
 
-download_uri="https://github.com/freedmand/textra/releases/download/0.1.0/textra-0.1.0.zip"
+download_uri="https://github.com/freedmand/textra/releases/download/0.2.0/textra-0.2.0.zip"
 
 install_env=TEXTRA_INSTALL
 bin_env=\$$install_env/bin

--- a/textra/version.swift
+++ b/textra/version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 /// The authoritative version of the application
-let VERSION = "0.1.0"
+let VERSION = "0.2.0"


### PR DESCRIPTION
From @rolandcrosby with minor version/readme changes. This PR adds support for specifying which locale to use for speech or text recognition via a new -l, --locale command line flag. If the user does not specify a locale, the default behavior of the recognition API is used.

Closes #8 